### PR TITLE
update missing or incorrect header guards

### DIFF
--- a/sources/c_api/compression_operations/qpl_deflate_slow.c
+++ b/sources/c_api/compression_operations/qpl_deflate_slow.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qpl_deflate_slow.h"
+
 /*
  *  Intel® Query Processing Library (Intel® QPL)
  *  Job API (public C API)

--- a/sources/c_api/compression_operations/qpl_deflate_slow.h
+++ b/sources/c_api/compression_operations/qpl_deflate_slow.h
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPL_DEFLATE_SLOW_H
+#define QPL_DEFLATE_SLOW_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/c_api/compression_operations/qpl_deflate_slow.c
+#include "crc.h"
+#include "deflate_defs.h"
+#include "bit_writer.h"
+#include "deflate_hash_table.h"
+#include "deflate_histogram.h"
+#include "own_deflate_job.h"
+#include "qplc_compression_consts.h"
+
+
+#endif

--- a/sources/c_api/legacy_hw_path/qpl_hw_get_size.c
+++ b/sources/c_api/legacy_hw_path/qpl_hw_get_size.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qpl_hw_get_size.h"
+
 /**
  * @date 3/23/2020
  * @brief @ref hw_get_job_size API implementation

--- a/sources/c_api/legacy_hw_path/qpl_hw_get_size.h
+++ b/sources/c_api/legacy_hw_path/qpl_hw_get_size.h
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPL_HW_GET_SIZE_H
+#define QPL_HW_GET_SIZE_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/c_api/legacy_hw_path/qpl_hw_get_size.c
+#include "own_defs.h"
+#include "hardware_state.h"
+
+
+#endif

--- a/sources/core-iaa/sources/aecs/datatables.c
+++ b/sources/core-iaa/sources/aecs/datatables.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "datatables.h"
+
 #include "own_compress.h"
 
 const uint32_t fixed_literals_table[286] = {

--- a/sources/core-iaa/sources/aecs/datatables.h
+++ b/sources/core-iaa/sources/aecs/datatables.h
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef DATATABLES_H
+#define DATATABLES_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/aecs/datatables.c
+#include "own_compress.h"
+
+
+#endif

--- a/sources/core-iaa/sources/aecs/hw_aecs_compress.c
+++ b/sources/core-iaa/sources/aecs/hw_aecs_compress.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "hw_aecs_compress.h"
+
 #include <assert.h>
 
 #include "own_hw_definitions.h"

--- a/sources/core-iaa/sources/aecs/hw_aecs_compress.h
+++ b/sources/core-iaa/sources/aecs/hw_aecs_compress.h
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HW_AECS_COMPRESS_H
+#define HW_AECS_COMPRESS_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/aecs/hw_aecs_compress.c
+#include <assert.h>
+#include "own_hw_definitions.h"
+#include "hw_aecs_api.h"
+#include "own_compress.h"
+#include "own_checkers.h"
+#include "simple_memory_ops_c_bind.h"
+#include "qplc_compression_consts.h"
+
+
+#endif

--- a/sources/core-iaa/sources/aecs/hw_aecs_decompress.c
+++ b/sources/core-iaa/sources/aecs/hw_aecs_decompress.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "hw_aecs_decompress.h"
+
 #include <assert.h>
 
 #include "hw_aecs_api.h"

--- a/sources/core-iaa/sources/aecs/hw_aecs_decompress.h
+++ b/sources/core-iaa/sources/aecs/hw_aecs_decompress.h
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HW_AECS_DECOMPRESS_H
+#define HW_AECS_DECOMPRESS_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/aecs/hw_aecs_decompress.c
+#include <assert.h>
+#include "hw_aecs_api.h"
+#include "own_compress.h"
+#include "own_hw_definitions.h"
+#include "own_checkers.h"
+#include "simple_memory_ops_c_bind.h"
+
+
+#endif

--- a/sources/core-iaa/sources/aecs/hw_huffman_table.c
+++ b/sources/core-iaa/sources/aecs/hw_huffman_table.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "hw_huffman_table.h"
+
 /**
  * @date 03/23/2020
  * @brief Internal HW API functions for @ref hw_descriptor_compress_init_deflate_base API implementation

--- a/sources/core-iaa/sources/aecs/hw_huffman_table.h
+++ b/sources/core-iaa/sources/aecs/hw_huffman_table.h
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HW_HUFFMAN_TABLE_H
+#define HW_HUFFMAN_TABLE_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/aecs/hw_huffman_table.c
+#include "hw_aecs_api.h"
+#include "own_compress.h"
+#include "simple_memory_ops_c_bind.h"
+
+
+#endif

--- a/sources/core-iaa/sources/bit_rev.c
+++ b/sources/core-iaa/sources/bit_rev.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "bit_rev.h"
+
 /*
  *  Intel® Query Processing Library (Intel® QPL)
  *  Data tables

--- a/sources/core-iaa/sources/bit_rev.h
+++ b/sources/core-iaa/sources/bit_rev.h
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef BIT_REV_H
+#define BIT_REV_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/bit_rev.c
+#include <stdint.h>
+
+
+#endif

--- a/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_base.c
+++ b/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_base.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "hw_analytic_descriptor_base.h"
+
 #include "hw_descriptors_api.h"
 #include "own_analytic_descriptor.h"
 

--- a/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_base.h
+++ b/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_base.h
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HW_ANALYTIC_DESCRIPTOR_BASE_H
+#define HW_ANALYTIC_DESCRIPTOR_BASE_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_base.c
+#include "hw_descriptors_api.h"
+#include "own_analytic_descriptor.h"
+
+
+#endif

--- a/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_operations.c
+++ b/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_operations.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "hw_analytic_descriptor_operations.h"
+
 #include "hw_descriptors_api.h"
 #include "own_analytic_descriptor.h"
 

--- a/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_operations.h
+++ b/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_operations.h
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HW_ANALYTIC_DESCRIPTOR_OPERATIONS_H
+#define HW_ANALYTIC_DESCRIPTOR_OPERATIONS_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_operations.c
+#include "hw_descriptors_api.h"
+#include "own_analytic_descriptor.h"
+
+
+#endif

--- a/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_suboperations.c
+++ b/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_suboperations.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "hw_analytic_descriptor_suboperations.h"
+
 #include <stdbool.h>
 #include "hw_descriptors_api.h"
 #include "own_hw_definitions.h"

--- a/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_suboperations.h
+++ b/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_suboperations.h
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HW_ANALYTIC_DESCRIPTOR_SUBOPERATIONS_H
+#define HW_ANALYTIC_DESCRIPTOR_SUBOPERATIONS_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/descriptors/hw_analytic_descriptor_suboperations.c
+#include <stdbool.h>
+#include "hw_descriptors_api.h"
+#include "own_hw_definitions.h"
+#include "own_analytic_descriptor.h"
+
+
+#endif

--- a/sources/core-iaa/sources/descriptors/hw_compress_descriptor.c
+++ b/sources/core-iaa/sources/descriptors/hw_compress_descriptor.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "hw_compress_descriptor.h"
+
 #include <assert.h>
 #include "hw_descriptors_api.h"
 #include "own_hw_definitions.h"

--- a/sources/core-iaa/sources/descriptors/hw_compress_descriptor.h
+++ b/sources/core-iaa/sources/descriptors/hw_compress_descriptor.h
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HW_COMPRESS_DESCRIPTOR_H
+#define HW_COMPRESS_DESCRIPTOR_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/descriptors/hw_compress_descriptor.c
+#include <assert.h>
+#include "hw_descriptors_api.h"
+#include "own_hw_definitions.h"
+#include "simple_memory_ops_c_bind.h"
+#include "hw_aecs_api.h"
+
+
+#endif

--- a/sources/core-iaa/sources/descriptors/hw_crc64_descriptor.c
+++ b/sources/core-iaa/sources/descriptors/hw_crc64_descriptor.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "hw_crc64_descriptor.h"
+
 #include <assert.h>
 
 #include "own_hw_definitions.h"

--- a/sources/core-iaa/sources/descriptors/hw_crc64_descriptor.h
+++ b/sources/core-iaa/sources/descriptors/hw_crc64_descriptor.h
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HW_CRC64_DESCRIPTOR_H
+#define HW_CRC64_DESCRIPTOR_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/descriptors/hw_crc64_descriptor.c
+#include <assert.h>
+#include "own_hw_definitions.h"
+#include "hw_descriptors_api.h"
+#include "simple_memory_ops_c_bind.h"
+
+
+#endif

--- a/sources/core-iaa/sources/descriptors/hw_decompress_descriptor.c
+++ b/sources/core-iaa/sources/descriptors/hw_decompress_descriptor.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "hw_decompress_descriptor.h"
+
 #include <stdbool.h>
 #include "hw_descriptors_api.h"
 #include "own_analytic_descriptor.h"

--- a/sources/core-iaa/sources/descriptors/hw_decompress_descriptor.h
+++ b/sources/core-iaa/sources/descriptors/hw_decompress_descriptor.h
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HW_DECOMPRESS_DESCRIPTOR_H
+#define HW_DECOMPRESS_DESCRIPTOR_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/descriptors/hw_decompress_descriptor.c
+#include <stdbool.h>
+#include "hw_descriptors_api.h"
+#include "own_analytic_descriptor.h"
+#include "own_compress.h"
+
+
+#endif

--- a/sources/core-iaa/sources/descriptors/hw_descriptor.c
+++ b/sources/core-iaa/sources/descriptors/hw_descriptor.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "hw_descriptor.h"
+
 #include "hw_descriptors_api.h"
 #include "own_analytic_descriptor.h"
 

--- a/sources/core-iaa/sources/descriptors/hw_descriptor.h
+++ b/sources/core-iaa/sources/descriptors/hw_descriptor.h
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HW_DESCRIPTOR_H
+#define HW_DESCRIPTOR_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-iaa/sources/descriptors/hw_descriptor.c
+#include "hw_descriptors_api.h"
+#include "own_analytic_descriptor.h"
+#include "simple_memory_ops_c_bind.h"
+
+
+#endif

--- a/sources/core-sw/src/compression/opt/placeholder.h
+++ b/sources/core-sw/src/compression/opt/placeholder.h
@@ -4,7 +4,12 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef PLACEHOLDER_H
+#define PLACEHOLDER_H
+
 /*
  *  Intel® Query Processing Library (Intel® QPL)
  *  SW Core API (Private API)
  */
+
+#endif

--- a/sources/core-sw/src/data/qplc_crc_tables.c
+++ b/sources/core-sw/src/data/qplc_crc_tables.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_crc_tables.h"
+
 /*
  *  Intel® Query Processing Library (Intel® QPL)
  *  SW Core API (Private API)

--- a/sources/core-sw/src/data/qplc_crc_tables.h
+++ b/sources/core-sw/src/data/qplc_crc_tables.h
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_CRC_TABLES_H
+#define QPLC_CRC_TABLES_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/data/qplc_crc_tables.c
+#include <stdint.h>
+
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_16u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_16u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPLC_UNPACK_16U_K0_H
+#define QPLC_UNPACK_16U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 9..16-bit data to words
  * @date 08/02/2020
@@ -541,3 +544,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_15u16u, (const uint8_t *src_ptr,
         px_qplc_unpack_Nu16u(src_ptr, num_elements, 0u, 15u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_8u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_8u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPLC_UNPACK_8U_K0_H
+#define QPLC_UNPACK_8U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 1..8-bit data to bytes
  * @date 08/02/2020
@@ -1010,3 +1013,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_7u8u, (const uint8_t *src_ptr,
         px_qplc_unpack_7u8u(src_ptr, num_elements, 0u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_16u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_16u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPLC_UNPACK_BE_16U_K0_H
+#define QPLC_UNPACK_BE_16U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 9..16-bit BE data to words
  * @date 07/06/2020
@@ -914,3 +917,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_16u16u, (const uint8_t *src_ptr,
         dst16u_ptr[i] = qplc_swap_bytes_16u(src16u_ptr[i]);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_32u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_32u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPLC_UNPACK_BE_32U_K0_H
+#define QPLC_UNPACK_BE_32U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 17..32-bit BE data to dwords
  * @date 07/06/2020
@@ -1911,3 +1914,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_32u32u, (const uint8_t *src_ptr,
         dst32u_ptr[i] = qplc_swap_bytes_32u(src32u_ptr[i]);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/opt/qplc_unpack_be_8u_k0.h
+++ b/sources/core-sw/src/filtering/opt/qplc_unpack_be_8u_k0.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef QPLC_UNPACK_BE_8U_K0_H
+#define QPLC_UNPACK_BE_8U_K0_H
+
 /**
  * @brief Contains implementation of functions for unpacking 1..8-bit BE data to bytes
  * @date 07/06/2020
@@ -547,3 +550,5 @@ OWN_OPT_FUN(void, k0_qplc_unpack_be_7u8u, (const uint8_t *src_ptr,
         px_qplc_unpack_be_Nu8u(src_ptr, num_elements, 0u, 7u, dst_ptr);
     }
 }
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_pack_16u.c
+++ b/sources/core-sw/src/filtering/qplc_pack_16u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_pack_16u.h"
+
 /**
  * @brief Contains implementation of functions for vector packing word integers to 9...16-bit integers
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_pack_16u.h
+++ b/sources/core-sw/src/filtering/qplc_pack_16u.h
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_PACK_16U_H
+#define QPLC_PACK_16U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_pack_16u.c
+#include "own_qplc_defs.h"
+#include "qplc_memop.h"
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_pack_32u.c
+++ b/sources/core-sw/src/filtering/qplc_pack_32u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_pack_32u.h"
+
 /**
  * @brief Contains implementation of functions for vector packing dword integers to 17...32-bit integers
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_pack_32u.h
+++ b/sources/core-sw/src/filtering/qplc_pack_32u.h
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_PACK_32U_H
+#define QPLC_PACK_32U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_pack_32u.c
+#include "own_qplc_defs.h"
+#include "qplc_memop.h"
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_pack_8u.c
+++ b/sources/core-sw/src/filtering/qplc_pack_8u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_pack_8u.h"
+
 /**
  * @brief Contains implementation of functions for vector packing byte integers to 1...8-bit integers
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_pack_8u.h
+++ b/sources/core-sw/src/filtering/qplc_pack_8u.h
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_PACK_8U_H
+#define QPLC_PACK_8U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_pack_8u.c
+#include "own_qplc_defs.h"
+#include "qplc_memop.h"
+#if PLATFORM >= K0
+#include "opt/qplc_pack_8u_k0.h"
+#endif
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_pack_be_16u.c
+++ b/sources/core-sw/src/filtering/qplc_pack_be_16u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_pack_be_16u.h"
+
 /**
  * @brief Contains implementation of functions for vector packing byte integers to 9...16-bit integers in BE format
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_pack_be_16u.h
+++ b/sources/core-sw/src/filtering/qplc_pack_be_16u.h
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_PACK_BE_16U_H
+#define QPLC_PACK_BE_16U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_pack_be_16u.c
+#include "own_qplc_defs.h"
+#if PLATFORM >= K0
+#include "opt/qplc_pack_be_16u_k0.h"
+#endif
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_pack_be_32u.c
+++ b/sources/core-sw/src/filtering/qplc_pack_be_32u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_pack_be_32u.h"
+
 /**
  * @brief Contains implementation of functions for vector packing dword integers to 17...32-bit integers in BE format
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_pack_be_32u.h
+++ b/sources/core-sw/src/filtering/qplc_pack_be_32u.h
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_PACK_BE_32U_H
+#define QPLC_PACK_BE_32U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_pack_be_32u.c
+#include "own_qplc_defs.h"
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_pack_be_8u.c
+++ b/sources/core-sw/src/filtering/qplc_pack_be_8u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_pack_be_8u.h"
+
 /**
  * @brief Contains implementation of functions for vector packing byte integers to 1...8-bit integers in BE format
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_pack_be_8u.h
+++ b/sources/core-sw/src/filtering/qplc_pack_be_8u.h
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_PACK_BE_8U_H
+#define QPLC_PACK_BE_8U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_pack_be_8u.c
+#include "own_qplc_defs.h"
+#include "qplc_memop.h"
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_pack_be_idx.c
+++ b/sources/core-sw/src/filtering/qplc_pack_be_idx.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_pack_be_idx.h"
+
 /**
  * @brief Contains implementation of functions for vector packing byte integers to 1-bit integers or indexes in BE format
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_pack_be_idx.h
+++ b/sources/core-sw/src/filtering/qplc_pack_be_idx.h
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_PACK_BE_IDX_H
+#define QPLC_PACK_BE_IDX_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_pack_be_idx.c
+#include "own_qplc_defs.h"
+#include "qplc_api.h"
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_pack_idx.c
+++ b/sources/core-sw/src/filtering/qplc_pack_idx.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_pack_idx.h"
+
 /**
  * @brief Contains implementation of functions for vector packing byte integers to 1-bit integers or indexes
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_pack_idx.h
+++ b/sources/core-sw/src/filtering/qplc_pack_idx.h
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_PACK_IDX_H
+#define QPLC_PACK_IDX_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_pack_idx.c
+#include "own_qplc_defs.h"
+#include "qplc_api.h"
+#if PLATFORM >= K0
+
+#include "opt/qplc_pack_idx_k0.h"
+
+#endif
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_unpack_16u.c
+++ b/sources/core-sw/src/filtering/qplc_unpack_16u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_unpack_16u.h"
+
 /**
  * @brief Contains implementation of functions for unpacking 9..16-bit data to words
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_unpack_16u.h
+++ b/sources/core-sw/src/filtering/qplc_unpack_16u.h
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_UNPACK_16U_H
+#define QPLC_UNPACK_16U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_unpack_16u.c
+#include "own_qplc_defs.h"
+#include "qplc_memop.h"
+#include "qplc_unpack.h"
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_unpack_32u.c
+++ b/sources/core-sw/src/filtering/qplc_unpack_32u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_unpack_32u.h"
+
 /**
  * @brief Contains implementation of functions for unpacking 17..32-bit data to dwords
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_unpack_32u.h
+++ b/sources/core-sw/src/filtering/qplc_unpack_32u.h
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_UNPACK_32U_H
+#define QPLC_UNPACK_32U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_unpack_32u.c
+#include "own_qplc_defs.h"
+#include "qplc_memop.h"
+#include "qplc_unpack.h"
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_unpack_8u.c
+++ b/sources/core-sw/src/filtering/qplc_unpack_8u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_unpack_8u.h"
+
 /**
  * @brief Contains implementation of functions for unpacking 1..8-bit data to bytes
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_unpack_8u.h
+++ b/sources/core-sw/src/filtering/qplc_unpack_8u.h
@@ -1,0 +1,21 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_UNPACK_8U_H
+#define QPLC_UNPACK_8U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_unpack_8u.c
+#include "own_qplc_defs.h"
+#include "qplc_memop.h"
+#include "qplc_unpack.h"
+#if PLATFORM >= K0
+
+#include "opt/qplc_unpack_8u_k0.h"
+
+#endif
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_unpack_be_16u.c
+++ b/sources/core-sw/src/filtering/qplc_unpack_be_16u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_unpack_be_16u.h"
+
 /**
  * @brief Contains implementation of functions for unpacking 9..16-bit BE data to words
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_unpack_be_16u.h
+++ b/sources/core-sw/src/filtering/qplc_unpack_be_16u.h
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_UNPACK_BE_16U_H
+#define QPLC_UNPACK_BE_16U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_unpack_be_16u.c
+#include "own_qplc_defs.h"
+#include "qplc_unpack.h"
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_unpack_be_32u.c
+++ b/sources/core-sw/src/filtering/qplc_unpack_be_32u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_unpack_be_32u.h"
+
 /**
  * @brief Contains implementation of functions for unpacking 17..32-bit BE data to dwords
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_unpack_be_32u.h
+++ b/sources/core-sw/src/filtering/qplc_unpack_be_32u.h
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_UNPACK_BE_32U_H
+#define QPLC_UNPACK_BE_32U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_unpack_be_32u.c
+#include "own_qplc_defs.h"
+#include "qplc_unpack.h"
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_unpack_be_8u.c
+++ b/sources/core-sw/src/filtering/qplc_unpack_be_8u.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_unpack_be_8u.h"
+
 /**
  * @brief Contains implementation of functions for unpacking 1..8-bit BE data to bytes
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_unpack_be_8u.h
+++ b/sources/core-sw/src/filtering/qplc_unpack_be_8u.h
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_UNPACK_BE_8U_H
+#define QPLC_UNPACK_BE_8U_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_unpack_be_8u.c
+#include "own_qplc_defs.h"
+#include "qplc_memop.h"
+#include "qplc_unpack.h"
+
+
+#endif

--- a/sources/core-sw/src/filtering/qplc_unpack_prle.c
+++ b/sources/core-sw/src/filtering/qplc_unpack_prle.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "qplc_unpack_prle.h"
+
 /**
  * @brief Contains implementation of functions for PRLE format unpacking to bytes, words & dwords
  * @date 07/06/2020

--- a/sources/core-sw/src/filtering/qplc_unpack_prle.h
+++ b/sources/core-sw/src/filtering/qplc_unpack_prle.h
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef QPLC_UNPACK_PRLE_H
+#define QPLC_UNPACK_PRLE_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/core-sw/src/filtering/qplc_unpack_prle.c
+#include "own_qplc_defs.h"
+#include "qplc_api.h"
+#include "qplc_memop.h"
+
+
+#endif

--- a/sources/isal/crc/crc64_base.c
+++ b/sources/isal/crc/crc64_base.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "crc64_base.h"
+
 #include "crc64.h"
 
 static const uint64_t crc64_ecma_refl_table[256] = {

--- a/sources/isal/crc/crc64_base.h
+++ b/sources/isal/crc/crc64_base.h
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef CRC64_BASE_H
+#define CRC64_BASE_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/isal/crc/crc64_base.c
+#include "crc64.h"
+
+
+#endif

--- a/sources/isal/crc/crc_base.c
+++ b/sources/isal/crc/crc_base.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
+
+#include "crc_base.h"
 #include "crc.h"
 
 static const uint16_t crc16tab[256] = {

--- a/sources/isal/crc/crc_base.h
+++ b/sources/isal/crc/crc_base.h
@@ -1,0 +1,14 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef CRC_BASE_H
+#define CRC_BASE_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/isal/crc/crc_base.c
+#include "crc.h"
+
+
+#endif

--- a/sources/isal/igzip/adler32_base.c
+++ b/sources/isal/igzip/adler32_base.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
+
+#include "adler32_base.h"
 #include <stddef.h>
 #include <stdint.h>
 #include "igzip_checksums.h"

--- a/sources/isal/igzip/adler32_base.h
+++ b/sources/isal/igzip/adler32_base.h
@@ -1,0 +1,16 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef ADLER32_BASE_H
+#define ADLER32_BASE_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/isal/igzip/adler32_base.c
+#include <stddef.h>
+#include <stdint.h>
+#include "igzip_checksums.h"
+
+
+#endif

--- a/sources/isal/igzip/huffman.h
+++ b/sources/isal/igzip/huffman.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#ifndef HUFFMAN_H
+#define HUFFMAN_H
+
 #include <stdint.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -359,3 +362,5 @@ static inline int compare(uint8_t * str1, uint8_t * str2, uint32_t max_length)
 
     return count;
 }
+
+#endif

--- a/sources/isal/igzip/hufftables_c.c
+++ b/sources/isal/igzip/hufftables_c.c
@@ -3,6 +3,8 @@
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
+
+#include "hufftables_c.h"
 #include <stdint.h>
 #include <igzip_lib.h>
 

--- a/sources/isal/igzip/hufftables_c.h
+++ b/sources/isal/igzip/hufftables_c.h
@@ -1,0 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef HUFFTABLES_C_H
+#define HUFFTABLES_C_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/isal/igzip/hufftables_c.c
+#include <stdint.h>
+#include <igzip_lib.h>
+
+
+#endif

--- a/sources/isal/igzip/igzip.c
+++ b/sources/isal/igzip/igzip.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "igzip.h"
+
 #define ASM
 
 #include <assert.h>

--- a/sources/isal/igzip/igzip.h
+++ b/sources/isal/igzip/igzip.h
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef IGZIP_H
+#define IGZIP_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/isal/igzip/igzip.c
+#include <assert.h>
+#include <string.h>
+#ifdef _WIN32
+# include <intrin.h>
+#endif
+#include "huffman.h"
+#include "bitbuf2.h"
+#include "igzip_lib.h"
+#include "crc.h"
+#include "repeated_char_result.h"
+#include "huff_codes.h"
+#include "encode_df.h"
+#include "igzip_level_buf_structs.h"
+#include "igzip_checksums.h"
+#include "igzip_wrapper.h"
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/endian.h>
+# define to_be32(x) bswap32(x)
+#elif defined (__APPLE__)
+#include <libkern/OSByteOrder.h>
+# define to_be32(x) OSSwapInt32(x)
+#elif defined (__GNUC__) && !defined (__MINGW32__)
+# include <byteswap.h>
+# define to_be32(x) bswap_32(x)
+#elif defined _WIN64
+# define to_be32(x) _byteswap_ulong(x)
+#endif
+
+
+#endif

--- a/sources/isal/igzip/igzip_base.c
+++ b/sources/isal/igzip/igzip_base.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "igzip_base.h"
+
 #include <stdint.h>
 #include "igzip_lib.h"
 #include "huffman.h"

--- a/sources/isal/igzip/igzip_base.h
+++ b/sources/isal/igzip/igzip_base.h
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef IGZIP_BASE_H
+#define IGZIP_BASE_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/isal/igzip/igzip_base.c
+#include <stdint.h>
+#include "igzip_lib.h"
+#include "huffman.h"
+#include "huff_codes.h"
+#include "bitbuf2.h"
+
+
+#endif

--- a/sources/isal/igzip/igzip_icf_base.c
+++ b/sources/isal/igzip/igzip_icf_base.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "igzip_icf_base.h"
+
 #include <stdint.h>
 #include "igzip_lib.h"
 #include "huffman.h"

--- a/sources/isal/igzip/igzip_icf_base.h
+++ b/sources/isal/igzip/igzip_icf_base.h
@@ -1,0 +1,20 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef IGZIP_ICF_BASE_H
+#define IGZIP_ICF_BASE_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/isal/igzip/igzip_icf_base.c
+#include <stdint.h>
+#include "igzip_lib.h"
+#include "huffman.h"
+#include "huff_codes.h"
+#include "encode_df.h"
+#include "igzip_level_buf_structs.h"
+#include "unaligned.h"
+
+
+#endif

--- a/sources/isal/igzip/igzip_icf_body.c
+++ b/sources/isal/igzip/igzip_icf_body.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "igzip_icf_body.h"
+
 #include "igzip_lib.h"
 #include "huffman.h"
 #include "encode_df.h"

--- a/sources/isal/igzip/igzip_icf_body.h
+++ b/sources/isal/igzip/igzip_icf_body.h
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef IGZIP_ICF_BODY_H
+#define IGZIP_ICF_BODY_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/isal/igzip/igzip_icf_body.c
+#include "igzip_lib.h"
+#include "huffman.h"
+#include "encode_df.h"
+#include "igzip_level_buf_structs.h"
+
+
+#endif

--- a/sources/isal/igzip/igzip_inflate.c
+++ b/sources/isal/igzip/igzip_inflate.c
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 
+#include "igzip_inflate.h"
+
 #include <stdint.h>
 #include "igzip_lib.h"
 #include "crc.h"

--- a/sources/isal/igzip/igzip_inflate.h
+++ b/sources/isal/igzip/igzip_inflate.h
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (C) 2024 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#ifndef IGZIP_INFLATE_H
+#define IGZIP_INFLATE_H
+
+// includes extracted from /home/ec2-user/code/bot-qpl-updates/sources/isal/igzip/igzip_inflate.c
+#include <stdint.h>
+#include "igzip_lib.h"
+#include "crc.h"
+#include "huff_codes.h"
+#include "igzip_checksums.h"
+#include "igzip_wrapper.h"
+#include "unaligned.h"
+#ifndef NO_STATIC_INFLATE_H
+#include "static_inflate.h"
+#endif
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/endian.h>
+# define bswap_32(x) bswap32(x)
+#elif defined (__APPLE__)
+#include <libkern/OSByteOrder.h>
+# define bswap_32(x) OSSwapInt32(x)
+#elif defined (__GNUC__) && !defined (__MINGW32__)
+# include <byteswap.h>
+#elif defined _WIN64
+# define bswap_32(x) _byteswap_ulong(x)
+#endif
+
+
+#endif

--- a/sources/isal/igzip/igzip_wrapper.h
+++ b/sources/isal/igzip/igzip_wrapper.h
@@ -5,6 +5,8 @@
  ******************************************************************************/
 
 #ifndef IGZIP_WRAPPER_H
+#define IGZIP_WRAPPER_H
+
 
 #define DEFLATE_METHOD 8
 #define ZLIB_DICT_FLAG (1 << 5)

--- a/sources/isal/igzip/static_inflate.h
+++ b/sources/isal/igzip/static_inflate.h
@@ -1349,7 +1349,6 @@ struct inflate_huff_code_small static_dist_huff_code = {
         0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000	}
 };
 
-#endif
 struct inflate_huff_code_large pregen_lit_huff_code = {
     .short_code_lookup = {
         0x24000102, 0x88010265, 0x44000103, 0xa8010277,
@@ -2682,3 +2681,4 @@ struct inflate_huff_code_small pregen_dist_huff_code = {
         0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000	}
 };
 
+#endif


### PR DESCRIPTION
# Description

This PR covers several fixes to header files which are missing include guards, or have include guards which are incorrect. In addition, it adds header files for .c source files which are missing header files.

All code updates were made by the Permanence AI Coder bot.

# Checklist

## All Submissions

- [ ] Attached log with the results of functional testing using `software_path` and/or `hardware_path`. Required testing coverage depends on the nature of changes, e.g., changes to the API or middle-layer imply testing of both, however changes focused on `core-iaa/` only require `hardware_path`. If testing is not possible on the contributor side (e.g., due to lack of resources), please let maintainers know. More information on testing is in [Documentation](https://intel.github.io/qpl/documentation/get_started_docs/testing.html).

## New Features

- [ ] Added copyrights for all new files.
- [ ] Added doxygen comments for all new APIs.
- [ ] Added relevant tests.
- [ ] Added relevant examples and documentation (if required).

## Bug Fixes

- [ ] Added relevant regression tests.
- [ ] Included information on how to reproduce the issue (either in a
      GitHub issue or in this PR).