### PR TITLE
replace for loops in QPL tests with std algorithms

### DIFF
--- a/tools/tests/functional/unit_tests/algorithmic/core_aggregates.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_aggregates.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 #include <array>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 #include "qpl_test_environment.hpp"
@@ -137,9 +138,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_bit_aggregates_8u, base) {
 
     {
         uint8_t* p_source_8u = (uint8_t*)source.data();
-        for (uint32_t indx = 0U; indx < TEST_BUFFER_SIZE; indx++) {
-            p_source_8u[indx] = 0U;
-        }
+        std::fill_n(p_source_8u, TEST_BUFFER_SIZE, 0U);
     }
 
     for (uint32_t length = 1U; length <= TEST_BUFFER_SIZE; length++) {
@@ -273,9 +272,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_aggregates_8u, base) {
 
     {
         uint8_t* p_source_8u = (uint8_t*)source.data();
-        for (uint32_t indx = 0U; indx < TEST_BUFFER_SIZE; indx++) {
-            p_source_8u[indx] = 0U;
-        }
+        std::fill_n(p_source_8u, TEST_BUFFER_SIZE, 0U);
     }
 
     for (uint32_t length = 1U; length <= TEST_BUFFER_SIZE; length++) {

--- a/tools/tests/functional/unit_tests/algorithmic/core_deflate_slow.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_deflate_slow.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 #include <array>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 
@@ -52,24 +53,16 @@ static inline qplc_slow_deflate_icf_body_t_ptr qplc_slow_deflate_icf_body() {
 
 static void init_hash_table(void)
 {
-    for (uint32_t indx = 0U; indx < D_SIZE_HASH_TABLE; indx++) {
-        hash_table[indx] = 0x80000000U;
-    }
-    for (uint32_t indx = 0U; indx < D_SIZE_HASH_STORE; indx++) {
-        hash_story[indx] = 0x00000000U;
-    }
+    std::fill_n(hash_table, D_SIZE_HASH_TABLE, 0x80000000U);
+    std::fill(std::begin(hash_story), std::end(hash_story), 0x00000000U);
 }
 
 static void init_histogram(isal_mod_hist *str_histogram_ptr)
 {
     uint32_t* d_hist = str_histogram_ptr->d_hist;
     uint32_t* ll_hist = str_histogram_ptr->ll_hist;
-    for (uint32_t indx = 0U; indx < 0x1e; indx++) {
-        d_hist[indx] = 0U;
-    }
-    for (uint32_t indx = 0U; indx < 0x201; indx++) {
-        ll_hist[indx] = 0U;
-    }
+    std::fill_n(d_hist, 0x1e, 0U);
+    std::fill_n(ll_hist, 0x201, 0U);
 }
 
 static void init_deflate_icf(void)

--- a/tools/tests/functional/unit_tests/algorithmic/core_expand.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_expand.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 #include <array>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 #include "qpl_test_environment.hpp"
@@ -24,22 +25,19 @@ qplc_expand_t_ptr qplc_expand(uint32_t index) {
 static void fill_buffer_8u(uint8_t* src, uint8_t* dst, uint32_t length) {
     uint8_t* p_src_8u = src;
     uint8_t* p_dst_8u = dst;
-    for (uint32_t indx = 0U; indx < length; indx++)
-        p_dst_8u[indx] = p_src_8u[indx];
+    std::copy_n(p_src_8u, length, p_dst_8u);
 }
 
 static void fill_buffer_16u(uint8_t* src, uint8_t* dst, uint32_t length) {
     uint16_t* p_src_16u = (uint16_t*)src;
     uint16_t* p_dst_16u = (uint16_t*)dst;
-    for (uint32_t indx = 0U; indx < length; indx++)
-        p_dst_16u[indx] = p_src_16u[indx];
+    std::copy_n(p_src_16u, length, p_dst_16u);
 }
 
 static void fill_buffer_32u(uint8_t* src, uint8_t* dst, uint32_t length) {
     uint32_t* p_src_32u = (uint32_t*)src;
     uint32_t* p_dst_32u = (uint32_t*)dst;
-    for (uint32_t indx = 0U; indx < length; indx++)
-        p_dst_32u[indx] = p_src_32u[indx];
+    std::copy_n(p_src_32u, length, p_dst_32u);
 }
 
 
@@ -156,9 +154,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_expand_8u, base) {
 
     {
         uint8_t* p_buffer_mask = (uint8_t*)mask.data();
-        for (uint32_t indx = 0U; indx < 16U; indx++) {
-            p_buffer_mask[indx] = 0U;
-        }
+        std::fill_n(p_buffer_mask, 16, 0U);
     }
 
     for (uint32_t length = 16U; length <= TEST_BUFFER_SIZE; length++) {
@@ -194,9 +190,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_expand_8u, base) {
 
     {
         uint8_t* p_buffer_mask = (uint8_t*)mask.data();
-        for (uint32_t indx = 0U; indx < 32U; indx++) {
-            p_buffer_mask[indx] = 0U;
-        }
+        std::fill_n(p_buffer_mask, 32, 0U);
     }
 
     for (uint32_t length = 33U; length <= TEST_BUFFER_SIZE; length++) {
@@ -215,9 +209,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_expand_8u, base) {
 
     {
         uint8_t* p_buffer_mask = (uint8_t*)mask.data();
-        for (uint32_t indx = 0U; indx < 32U; indx++) {
-            p_buffer_mask[indx] = 1U;
-        }
+        std::fill_n(p_buffer_mask, 32, 1U);
     }
 
     for (uint32_t length = 33U; length <= TEST_BUFFER_SIZE; length++) {
@@ -275,9 +267,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_expand_16u, base) {
 
     {
         uint8_t* p_buffer_mask = (uint8_t*)mask.data();
-        for (uint32_t indx = 0U; indx < 16U; indx++) {
-            p_buffer_mask[indx] = 0U;
-        }
+        std::fill_n(p_buffer_mask, 16, 0U);
     }
 
     for (uint32_t length = 16U; length <= TEST_BUFFER_SIZE; length++) {
@@ -313,9 +303,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_expand_16u, base) {
 
     {
         uint8_t* p_buffer_mask = (uint8_t*)mask.data();
-        for (uint32_t indx = 0U; indx < 32U; indx++) {
-            p_buffer_mask[indx] = 0U;
-        }
+        std::fill_n(p_buffer_mask, 32, 0U);
     }
 
     for (uint32_t length = 33U; length <= TEST_BUFFER_SIZE; length++) {
@@ -334,9 +322,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_expand_16u, base) {
 
     {
         uint8_t* p_buffer_mask = (uint8_t*)mask.data();
-        for (uint32_t indx = 0U; indx < 32U; indx++) {
-            p_buffer_mask[indx] = 1U;
-        }
+        std::fill_n(p_buffer_mask, 32, 1U);
     }
 
     for (uint32_t length = 33U; length <= TEST_BUFFER_SIZE; length++) {
@@ -393,9 +379,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_expand_32u, base) {
 
     {
         uint8_t* p_buffer_mask = (uint8_t*)mask.data();
-        for (uint32_t indx = 0U; indx < 16U; indx++) {
-            p_buffer_mask[indx] = 0U;
-        }
+        std::fill_n(p_buffer_mask, 16, 0U);
     }
 
     for (uint32_t length = 16U; length <= TEST_BUFFER_SIZE; length++) {
@@ -431,9 +415,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_expand_32u, base) {
 
     {
         uint8_t* p_buffer_mask = (uint8_t*)mask.data();
-        for (uint32_t indx = 0U; indx < 32U; indx++) {
-            p_buffer_mask[indx] = 0U;
-        }
+        std::fill_n(p_buffer_mask, 32, 0U);
     }
 
     for (uint32_t length = 33U; length <= TEST_BUFFER_SIZE; length++) {
@@ -452,9 +434,7 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_expand_32u, base) {
 
     {
         uint8_t* p_buffer_mask = (uint8_t*)mask.data();
-        for (uint32_t indx = 0U; indx < 32U; indx++) {
-            p_buffer_mask[indx] = 1U;
-        }
+        std::fill_n(p_buffer_mask, 32, 1U);
     }
 
     for (uint32_t length = 33U; length <= TEST_BUFFER_SIZE; length++) {

--- a/tools/tests/functional/unit_tests/algorithmic/core_extract.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_extract.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 #include <array>
+#include <algorithm>
 #include <vector>
 #include "gtest/gtest.h"
 
@@ -30,9 +31,7 @@ qplc_extract_i_t_ptr qplc_extract_i(uint32_t index) {
 static void fill_buffer_8u(uint8_t* src, uint8_t* dst, uint32_t length) {
     uint8_t* p_src_8u = src;
     uint8_t* p_dst_8u = dst;
-    for (uint32_t indx = 0U; indx < length; indx++) {
-        p_dst_8u[indx] = p_src_8u[indx];
-    }
+    std::copy_n(p_src_8u, length, p_dst_8u);
 }
 
 static uint32_t ref_qplc_extract_8u(const uint8_t* src_ptr,
@@ -55,9 +54,7 @@ static uint32_t ref_qplc_extract_8u(const uint8_t* src_ptr,
     const uint32_t stop = ((*index_ptr + length) > high_value) ? (high_value + 1U - *index_ptr) : length;
 
     src_ptr += start;
-    for (uint32_t idx = 0U; idx < (stop - start); idx++) {
-        dst_ptr[idx] = src_ptr[idx];
-    }
+    std::copy_n(src_ptr, stop - start, dst_ptr);
     *index_ptr += length;
     return (stop - start);
 }
@@ -84,9 +81,7 @@ static uint32_t ref_qplc_extract_16u(const uint8_t* src_ptr,
     const uint32_t stop = ((*index_ptr + length) > high_value) ? (high_value + 1U - *index_ptr) : length;
 
     src_16u_ptr += start;
-    for (uint32_t idx = 0U; idx < (stop - start); idx++) {
-        dst_16u_ptr[idx] = src_16u_ptr[idx];
-    }
+    std::copy_n(src_16u_ptr, stop - start, dst_16u_ptr);
     *index_ptr += length;
     return (stop - start);
 }
@@ -113,9 +108,7 @@ static uint32_t ref_qplc_extract_32u(const uint8_t* src_ptr,
     const uint32_t stop = ((*index_ptr + length) > high_value) ? (high_value + 1U - *index_ptr) : length;
 
     src_32u_ptr += start;
-    for (uint32_t idx = 0U; idx < (stop - start); idx++) {
-        dst_32u_ptr[idx] = src_32u_ptr[idx];
-    }
+    std::copy_n(src_32u_ptr, stop - start, dst_32u_ptr);
     *index_ptr += length;
     return (stop - start);
 }

--- a/tools/tests/functional/unit_tests/algorithmic/core_pack_16u.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_pack_16u.cpp
@@ -103,8 +103,8 @@ static void fill_src_buffer_16u(uint8_t* src, uint8_t* dst, size_t length, uint3
     uint16_t *p_src_16u = (uint16_t*)src;
     uint16_t *p_dst_16u = (uint16_t*)dst;
     const uint16_t mask = (1U << nbits) - 1U;
-    for (uint32_t indx = 0; indx < length; indx++)
-        p_dst_16u[indx] = p_src_16u[indx] & mask;
+    std::transform(p_src_16u, p_src_16u + length, p_dst_16u,
+               [mask](auto x) { return x & mask; });
 }
 
 constexpr uint32_t TEST_BUFFER_SIZE = 64U;

--- a/tools/tests/functional/unit_tests/algorithmic/core_pack_32u.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_pack_32u.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 #include <array>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 #include "qpl_test_environment.hpp"
@@ -164,8 +165,8 @@ static void fill_src_buffer_32u(uint8_t* src, uint8_t* dst, size_t length, uint3
     uint32_t *p_src_32u = (uint32_t*)src;
     uint32_t *p_dst_32u = (uint32_t*)dst;
     const uint32_t mask = (1U << nbits) - 1U;
-    for (uint32_t indx = 0U; indx < length; indx++)
-        p_dst_32u[indx] = p_src_32u[indx] & mask;
+    std::transform(p_src_32u, p_src_32u + length, p_dst_32u,
+               [mask](auto x) { return x & mask; });
 }
 
 constexpr uint32_t TEST_BUFFER_SIZE = 64U;

--- a/tools/tests/functional/unit_tests/algorithmic/core_select.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_select.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 #include <array>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 #include "qpl_test_environment.hpp"
@@ -28,9 +29,7 @@ qplc_select_i_t_ptr qplc_select_i(uint32_t index) {
 static void fill_buffer_8u(uint8_t* src, uint8_t* dst, uint32_t length) {
     uint8_t* p_src_8u = src;
     uint8_t* p_dst_8u = dst;
-    for (uint32_t indx = 0U; indx < length; indx++) {
-        p_dst_8u[indx] = p_src_8u[indx];
-    }
+    std::copy_n(p_src_8u, length, p_dst_8u);
 }
 
 static uint32_t ref_qplc_select_8u(const uint8_t* src_ptr,

--- a/tools/tests/functional/unit_tests/algorithmic/core_unpack_16u.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_unpack_16u.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 #include <array>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 #include "qpl_test_environment.hpp"
@@ -30,17 +31,15 @@ static void fill_src_buffer_16u(uint8_t* src, uint8_t* dst, uint32_t length, uin
     uint16_t* p_src_16u = (uint16_t*)src;
     uint16_t* p_dst_16u = (uint16_t*)dst;
     const uint16_t mask = (1U << nbits) - 1U;
-    for (uint32_t indx = 0; indx < length; indx++) {
-        p_dst_16u[indx] = p_src_16u[indx] & mask;
-    }
+    std::transform(p_src_16u, p_src_16u + length,
+                p_dst_16u,
+                [&mask](auto x) { return x & mask; });
 }
 
 static void fill_reference_buffer_16u(uint8_t* src, uint8_t* dst, uint32_t length) {
     uint16_t* p_src_16u = (uint16_t*)src;
     uint16_t* p_dst_16u = (uint16_t*)dst;
-    for (uint32_t indx = 0; indx < length; indx++) {
-        p_dst_16u[indx] = p_src_16u[indx];
-    }
+    std::copy_n(p_src_16u, length, p_dst_16u);
 }
 
 constexpr uint32_t TEST_BUFFER_SIZE = 64U;

--- a/tools/tests/functional/unit_tests/algorithmic/core_unpack_32u.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_unpack_32u.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 #include <array>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 #include "qpl_test_environment.hpp"
@@ -30,17 +31,14 @@ static void fill_src_buffer_32u(uint8_t* src, uint8_t* dst, uint32_t length, uin
     uint32_t* p_src_32u = (uint32_t*)src;
     uint32_t* p_dst_32u = (uint32_t*)dst;
     const uint32_t mask = (1U << nbits) - 1U;
-    for (uint32_t indx = 0; indx < length; indx++) {
-        p_dst_32u[indx] = p_src_32u[indx] & mask;
-    }
+    std::transform(p_src_32u, p_src_32u + length, p_dst_32u,
+               [mask](auto x) { return x & mask; });
 }
 
 static void fill_reference_buffer_32u(uint8_t* src, uint8_t* dst, uint32_t length) {
     uint32_t* p_src_32u = (uint32_t*)src;
     uint32_t* p_dst_32u = (uint32_t*)dst;
-    for (uint32_t indx = 0; indx < length; indx++) {
-        p_dst_32u[indx] = p_src_32u[indx];
-    }
+    std::copy_n(p_src_32u, length, p_dst_32u);
 }
 
 constexpr uint32_t TEST_BUFFER_SIZE = 64U;

--- a/tools/tests/functional/unit_tests/algorithmic/core_unpack_be_16u.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_unpack_be_16u.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 #include <array>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 #include "qpl_test_environment.hpp"
@@ -30,17 +31,13 @@ static void fill_src_buffer_16u(uint8_t* src, uint8_t* dst, uint32_t length, uin
     uint16_t* p_src_16u = (uint16_t*)src;
     uint16_t* p_dst_16u = (uint16_t*)dst;
     const uint16_t mask = (1U << nbits) - 1U;
-    for (uint32_t indx = 0; indx < length; indx++) {
-        p_dst_16u[indx] = p_src_16u[indx] & mask;
-    }
+    std::transform(p_src_16u, p_src_16u + length, p_dst_16u, [&mask](auto x) { return x & mask; });
 }
 
 static void fill_reference_buffer_16u(uint8_t* src, uint8_t* dst, uint32_t length) {
     uint16_t* p_src_16u = (uint16_t*)src;
     uint16_t* p_dst_16u = (uint16_t*)dst;
-    for (uint32_t indx = 0; indx < length; indx++) {
-        p_dst_16u[indx] = p_src_16u[indx];
-    }
+    std::copy(p_src_16u, p_src_16u + length, p_dst_16u);
 }
 
 constexpr uint32_t TEST_BUFFER_SIZE = 64U;

--- a/tools/tests/functional/unit_tests/algorithmic/core_unpack_be_32u.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_unpack_be_32u.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
 #include <array>
+#include <algorithm>
 
 #include "gtest/gtest.h"
 #include "qpl_test_environment.hpp"
@@ -30,17 +31,14 @@ static void fill_src_buffer_32u(uint8_t* src, uint8_t* dst, uint32_t length, uin
     uint32_t* p_src_32u = (uint32_t*)src;
     uint32_t* p_dst_32u = (uint32_t*)dst;
     const uint32_t mask = (1U << nbits) - 1U;
-    for (uint32_t indx = 0; indx < length; indx++) {
-        p_dst_32u[indx] = p_src_32u[indx] & mask;
-    }
+    std::transform(p_src_32u, p_src_32u + length, p_dst_32u,
+               [mask](auto x) { return x & mask; });
 }
 
 static void fill_reference_buffer_32u(uint8_t* src, uint8_t* dst, uint32_t length) {
     uint32_t* p_src_32u = (uint32_t*)src;
     uint32_t* p_dst_32u = (uint32_t*)dst;
-    for (uint32_t indx = 0; indx < length; indx++) {
-        p_dst_32u[indx] = p_src_32u[indx];
-    }
+    std::copy_n(p_src_32u, length, p_dst_32u);
 }
 
 constexpr uint32_t TEST_BUFFER_SIZE = 64U;

--- a/tools/tests/functional/unit_tests/algorithmic/core_unpack_prle.cpp
+++ b/tools/tests/functional/unit_tests/algorithmic/core_unpack_prle.cpp
@@ -56,40 +56,28 @@ qplc_unpack_prle_t_ptr qplc_unpack_prle(uint32_t index) {
 }
 
 static void ref_qplc_set_8u(uint8_t value, uint8_t* p_dst, uint32_t length) {
-    for (uint32_t indx = 0U; indx < length; indx++) {
-        p_dst[indx] = value;
-    }
+    std::fill_n(p_dst, length, value);
 }
 
 static void ref_qplc_set_16u(uint16_t value, uint16_t* p_dst, uint32_t length) {
-    for (uint32_t indx = 0U; indx < length; indx++) {
-        p_dst[indx] = value;
-    }
+    std::fill_n(p_dst, length, value);
 }
 
 static void ref_qplc_set_32u(uint32_t value, uint32_t* p_dst, uint32_t length) {
-    for (uint32_t indx = 0U; indx < length; indx++) {
-        p_dst[indx] = value;
-    }
+    std::fill_n(p_dst, length, value);
 }
 
 
 static void ref_qplc_copy_8u(const uint8_t* p_src, uint8_t* p_dst, uint32_t length) {
-    for (uint32_t indx = 0U; indx < length; indx++) {
-        p_dst[indx] = p_src[indx];
-    }
+    std::copy_n(p_src, length, p_dst);
 }
 
 static void ref_qplc_copy_16u(const uint16_t* p_src, uint16_t* p_dst, uint32_t length) {
-    for (uint32_t indx = 0U; indx < length; indx++) {
-        p_dst[indx] = p_src[indx];
-    }
+    std::copy_n(p_src, length, p_dst);
 }
 
 static void ref_qplc_copy_32u(const uint32_t* p_src, uint32_t* p_dst, uint32_t length) {
-    for (uint32_t indx = 0U; indx < length; indx++) {
-        p_dst[indx] = p_src[indx];
-    }
+    std::copy_n(p_src, length, p_dst);
 }
 
 
@@ -531,11 +519,9 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_unpack_prle_8u, base) {
         uint8_t* p_source_8u = (uint8_t*)source.data();
         uint32_t* p_value_32u = (uint32_t*)value.data();
         uint32_t* p_ref_value_32u = (uint32_t*)ref_value.data();
-        for (uint32_t indx = 0U; indx < TEST_BUFFER_SIZE; indx++) {
-            p_source_8u[indx] = 1U;
-            p_value_32u[indx] = 1U;
-            p_ref_value_32u[indx] = 1U;
-        }
+        std::fill_n(p_source_8u, TEST_BUFFER_SIZE, 1U);
+        std::fill_n(p_value_32u, TEST_BUFFER_SIZE, 1U);
+        std::fill_n(p_ref_value_32u, TEST_BUFFER_SIZE, 1U);
     }
     for (uint32_t bit_width = 7U; bit_width <= 8U; bit_width++) {
         for (uint32_t length = 1U; length <= TEST_BUFFER_SIZE; length++) {
@@ -573,11 +559,9 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_unpack_prle_8u, base) {
         uint8_t* p_source_8u = (uint8_t*)source.data();
         uint32_t* p_value_32u = (uint32_t*)value.data();
         uint32_t* p_ref_value_32u = (uint32_t*)ref_value.data();
-        for (uint32_t indx = 0U; indx < TEST_BUFFER_SIZE; indx++) {
-            p_source_8u[indx] = 0x8FU;
-            p_value_32u[indx] = 0x8FU;
-            p_ref_value_32u[indx] = 0x8FU;
-        }
+        std::fill_n(p_source_8u, TEST_BUFFER_SIZE, 0x8FU);
+        std::fill_n(p_value_32u, TEST_BUFFER_SIZE, 0x8FU);
+        std::fill_n(p_ref_value_32u, TEST_BUFFER_SIZE, 0x8FU);
     }
     for (uint32_t bit_width = 7U; bit_width <= 8U; bit_width++) {
         for (uint32_t length = 1U; length <= TEST_BUFFER_SIZE; length++) {
@@ -625,11 +609,9 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_unpack_prle_16u, base) {
         uint16_t* p_source_16u = (uint16_t*)source.data();
         uint32_t* p_value_32u = (uint32_t*)value.data();
         uint32_t* p_ref_value_32u = (uint32_t*)ref_value.data();
-        for (uint32_t indx = 0U; indx < TEST_BUFFER_SIZE; indx++) {
-            p_source_16u[indx] = 1U;
-            p_value_32u[indx] = 1U;
-            p_ref_value_32u[indx] = 1U;
-        }
+        std::fill_n(p_source_16u, TEST_BUFFER_SIZE, 1U);
+        std::fill_n(p_value_32u, TEST_BUFFER_SIZE, 1U);
+        std::fill_n(p_ref_value_32u, TEST_BUFFER_SIZE, 1U);
     }
     for (uint32_t bit_width = 15U; bit_width <= 16U; bit_width++) {
         for (uint32_t length = 1U; length <= TEST_BUFFER_SIZE; length++) {
@@ -667,11 +649,9 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_unpack_prle_16u, base) {
         uint16_t* p_source_16u = (uint16_t*)source.data();
         uint32_t* p_value_32u = (uint32_t*)value.data();
         uint32_t* p_ref_value_32u = (uint32_t*)ref_value.data();
-        for (uint32_t indx = 0U; indx < TEST_BUFFER_SIZE; indx++) {
-            p_source_16u[indx] = 0x8FU;
-            p_value_32u[indx] = 0x8FU;
-            p_ref_value_32u[indx] = 0x8FU;
-        }
+        std::fill_n(p_source_16u, TEST_BUFFER_SIZE, 0x8FU);
+        std::fill_n(p_value_32u, TEST_BUFFER_SIZE, 0x8FU);
+        std::fill_n(p_ref_value_32u, TEST_BUFFER_SIZE, 0x8FU);
     }
     for (uint32_t bit_width = 15U; bit_width <= 16U; bit_width++) {
         for (uint32_t length = 1U; length <= TEST_BUFFER_SIZE; length++) {
@@ -720,11 +700,9 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_unpack_prle_32u, base) {
         uint32_t* p_source_32u = (uint32_t*)source.data();
         uint32_t* p_value_32u = (uint32_t*)value.data();
         uint32_t* p_ref_value_32u = (uint32_t*)ref_value.data();
-        for (uint32_t indx = 0U; indx < TEST_BUFFER_SIZE; indx++) {
-            p_source_32u[indx] = 1U;
-            p_value_32u[indx] = 1U;
-            p_ref_value_32u[indx] = 1U;
-        }
+        std::fill_n(p_source_32u, TEST_BUFFER_SIZE, 1U);
+        std::fill_n(p_value_32u, TEST_BUFFER_SIZE, 1U);
+        std::fill_n(p_ref_value_32u, TEST_BUFFER_SIZE, 1U);
     }
     for (uint32_t indx_bit_width = 0U; indx_bit_width < 3U; indx_bit_width++) {
         const uint32_t bit_width = p_bit_witdh[indx_bit_width];
@@ -763,11 +741,9 @@ QPL_UNIT_API_ALGORITHMIC_TEST(qplc_unpack_prle_32u, base) {
         uint32_t* p_source_32u = (uint32_t*)source.data();
         uint32_t* p_value_32u = (uint32_t*)value.data();
         uint32_t* p_ref_value_32u = (uint32_t*)ref_value.data();
-        for (uint32_t indx = 0U; indx < TEST_BUFFER_SIZE; indx++) {
-            p_source_32u[indx] = 0x8FU;
-            p_value_32u[indx] = 0x8FU;
-            p_ref_value_32u[indx] = 0x8FU;
-        }
+        std::fill_n(p_source_32u, TEST_BUFFER_SIZE, 0x8FU);
+        std::fill_n(p_value_32u, TEST_BUFFER_SIZE, 0x8FU);
+        std::fill_n(p_ref_value_32u, TEST_BUFFER_SIZE, 0x8FU);
     }
     for (uint32_t indx_bit_width = 0U; indx_bit_width < 3U; indx_bit_width++) {
         const uint32_t bit_width = p_bit_witdh[indx_bit_width];


### PR DESCRIPTION
# Description

The code changes in this PR were generated automatically by the Permanence AI Coder and reviewed by myself. This code improvement PR applies a modernization pass to algorithmic unit tests in QPL to replace several instances of for loops with equivalent uses of `std::copy`, `std::copy_n`, `std::fill`, `std::fill_n`, and `std::transform`. The goal is to apply gradual modernization transformations to the C++ code in QPL as part of ongoing modernization efforts.


# Checklist
Full test run summary shows six expected test failures:
```
[  FAILED  ] 6 tests, listed below:
[  FAILED  ] ta_c_api_deflate_stateful.dynamic_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.dynamic_high_verify
[  FAILED  ] ta_c_api_deflate_stateful.fixed_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.fixed_high_verify
[  FAILED  ] ta_c_api_deflate_stateful.static_default_verify
[  FAILED  ] ta_c_api_deflate_stateful.static_high_verify
```

Explicit test run of ta_unit* tests show all passing:
```
./qpl_install/bin/tests --dataset=../qpl//tools/testdata/ --gtest_filter=ta_unit*
Tests seed = 1721404112
Note: Google Test filter = ta_unit*
[==========] Running 47 tests from 42 test suites.
[----------] Global test environment set-up.
[----------] 1 test from ta_unit_api_qplc_bit_aggregates_8u
[ RUN      ] ta_unit_api_qplc_bit_aggregates_8u.base
[       OK ] ta_unit_api_qplc_bit_aggregates_8u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_bit_aggregates_8u (1 ms total)

[----------] 1 test from ta_unit_api_qplc_aggregates_8u
[ RUN      ] ta_unit_api_qplc_aggregates_8u.base
[       OK ] ta_unit_api_qplc_aggregates_8u.base (1 ms)
[----------] 1 test from ta_unit_api_qplc_aggregates_8u (1 ms total)

[----------] 1 test from ta_unit_api_qplc_aggregates_16u
[ RUN      ] ta_unit_api_qplc_aggregates_16u.base
[       OK ] ta_unit_api_qplc_aggregates_16u.base (1 ms)
[----------] 1 test from ta_unit_api_qplc_aggregates_16u (1 ms total)

[----------] 1 test from ta_unit_api_qplc_aggregates_32u
[ RUN      ] ta_unit_api_qplc_aggregates_32u.base
[       OK ] ta_unit_api_qplc_aggregates_32u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_aggregates_32u (0 ms total)

[----------] 1 test from ta_unit_api_bit_writer_t
[ RUN      ] ta_unit_api_bit_writer_t.written_size
[       OK ] ta_unit_api_bit_writer_t.written_size (0 ms)
[----------] 1 test from ta_unit_api_bit_writer_t (0 ms total)

[----------] 1 test from ta_unit_api_deflate_histogramm
[ RUN      ] ta_unit_api_deflate_histogramm.offset_index_calculation
[       OK ] ta_unit_api_deflate_histogramm.offset_index_calculation (0 ms)
[----------] 1 test from ta_unit_api_deflate_histogramm (0 ms total)

[----------] 1 test from ta_unit_api_qplc_deflate_slow_icf
[ RUN      ] ta_unit_api_qplc_deflate_slow_icf.base
[       OK ] ta_unit_api_qplc_deflate_slow_icf.base (2 ms)
[----------] 1 test from ta_unit_api_qplc_deflate_slow_icf (2 ms total)

[----------] 1 test from ta_unit_api_qplc_expand_8u
[ RUN      ] ta_unit_api_qplc_expand_8u.base
[       OK ] ta_unit_api_qplc_expand_8u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_expand_8u (0 ms total)

[----------] 1 test from ta_unit_api_qplc_expand_16u
[ RUN      ] ta_unit_api_qplc_expand_16u.base
[       OK ] ta_unit_api_qplc_expand_16u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_expand_16u (0 ms total)

[----------] 1 test from ta_unit_api_qplc_expand_32u
[ RUN      ] ta_unit_api_qplc_expand_32u.base
[       OK ] ta_unit_api_qplc_expand_32u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_expand_32u (0 ms total)

[----------] 1 test from ta_unit_api_qplc_extract_8u
[ RUN      ] ta_unit_api_qplc_extract_8u.base
[       OK ] ta_unit_api_qplc_extract_8u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_extract_8u (0 ms total)

[----------] 1 test from ta_unit_api_qplc_extract_16u
[ RUN      ] ta_unit_api_qplc_extract_16u.base
[       OK ] ta_unit_api_qplc_extract_16u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_extract_16u (0 ms total)

[----------] 1 test from ta_unit_api_qplc_extract_32u
[ RUN      ] ta_unit_api_qplc_extract_32u.base
[       OK ] ta_unit_api_qplc_extract_32u.base (1 ms)
[----------] 1 test from ta_unit_api_qplc_extract_32u (1 ms total)

[----------] 1 test from ta_unit_api_qplc_extract_8u_i
[ RUN      ] ta_unit_api_qplc_extract_8u_i.base
[       OK ] ta_unit_api_qplc_extract_8u_i.base (1 ms)
[----------] 1 test from ta_unit_api_qplc_extract_8u_i (1 ms total)

[----------] 1 test from ta_unit_api_qplc_extract_16u_i
[ RUN      ] ta_unit_api_qplc_extract_16u_i.base
[       OK ] ta_unit_api_qplc_extract_16u_i.base (1 ms)
[----------] 1 test from ta_unit_api_qplc_extract_16u_i (1 ms total)

[----------] 1 test from ta_unit_api_qplc_extract_32u_i
[ RUN      ] ta_unit_api_qplc_extract_32u_i.base
[       OK ] ta_unit_api_qplc_extract_32u_i.base (3 ms)
[----------] 1 test from ta_unit_api_qplc_extract_32u_i (3 ms total)

[----------] 2 tests from ta_unit_api_own_move_8u
[ RUN      ] ta_unit_api_own_move_8u.forward_direction
[       OK ] ta_unit_api_own_move_8u.forward_direction (0 ms)
[ RUN      ] ta_unit_api_own_move_8u.backward_direction
[       OK ] ta_unit_api_own_move_8u.backward_direction (0 ms)
[----------] 2 tests from ta_unit_api_own_move_8u (0 ms total)

[----------] 1 test from ta_unit_api_qplc_pack_16u
[ RUN      ] ta_unit_api_qplc_pack_16u.base
[       OK ] ta_unit_api_qplc_pack_16u.base (1 ms)
[----------] 1 test from ta_unit_api_qplc_pack_16u (1 ms total)

[----------] 1 test from ta_unit_api_qplc_pack_32u
[ RUN      ] ta_unit_api_qplc_pack_32u.base
[       OK ] ta_unit_api_qplc_pack_32u.base (4 ms)
[----------] 1 test from ta_unit_api_qplc_pack_32u (4 ms total)

[----------] 1 test from ta_unit_api_qplc_pack_8u
[ RUN      ] ta_unit_api_qplc_pack_8u.base
[       OK ] ta_unit_api_qplc_pack_8u.base (1 ms)
[----------] 1 test from ta_unit_api_qplc_pack_8u (1 ms total)

[----------] 1 test from ta_unit_api_qplc_pack_index_be_8u16u
[ RUN      ] ta_unit_api_qplc_pack_index_be_8u16u.base
[       OK ] ta_unit_api_qplc_pack_index_be_8u16u.base (12 ms)
[----------] 1 test from ta_unit_api_qplc_pack_index_be_8u16u (12 ms total)

[----------] 1 test from ta_unit_api_qplc_pack_index_be_8u32u
[ RUN      ] ta_unit_api_qplc_pack_index_be_8u32u.base
[       OK ] ta_unit_api_qplc_pack_index_be_8u32u.base (20 ms)
[----------] 1 test from ta_unit_api_qplc_pack_index_be_8u32u (20 ms total)

[----------] 1 test from ta_unit_api_qplc_pack_idx_8u
[ RUN      ] ta_unit_api_qplc_pack_idx_8u.base
[       OK ] ta_unit_api_qplc_pack_idx_8u.base (472 ms)
[----------] 1 test from ta_unit_api_qplc_pack_idx_8u (472 ms total)

[----------] 1 test from ta_unit_api_qplc_pack_idx_8u16u
[ RUN      ] ta_unit_api_qplc_pack_idx_8u16u.base
[       OK ] ta_unit_api_qplc_pack_idx_8u16u.base (11 ms)
[----------] 1 test from ta_unit_api_qplc_pack_idx_8u16u (11 ms total)

[----------] 1 test from ta_unit_api_qplc_pack_idx_8u32u
[ RUN      ] ta_unit_api_qplc_pack_idx_8u32u.base
[       OK ] ta_unit_api_qplc_pack_idx_8u32u.base (1238 ms)
[----------] 1 test from ta_unit_api_qplc_pack_idx_8u32u (1238 ms total)

[----------] 1 test from ta_unit_api_qplc_select_8u
[ RUN      ] ta_unit_api_qplc_select_8u.base
[       OK ] ta_unit_api_qplc_select_8u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_select_8u (0 ms total)

[----------] 1 test from ta_unit_api_qplc_select_16u
[ RUN      ] ta_unit_api_qplc_select_16u.base
[       OK ] ta_unit_api_qplc_select_16u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_select_16u (0 ms total)

[----------] 1 test from ta_unit_api_qplc_select_32u
[ RUN      ] ta_unit_api_qplc_select_32u.base
[       OK ] ta_unit_api_qplc_select_32u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_select_32u (0 ms total)

[----------] 1 test from ta_unit_api_qplc_select_8u_i
[ RUN      ] ta_unit_api_qplc_select_8u_i.base
[       OK ] ta_unit_api_qplc_select_8u_i.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_select_8u_i (0 ms total)

[----------] 1 test from ta_unit_api_qplc_select_16u_i
[ RUN      ] ta_unit_api_qplc_select_16u_i.base
[       OK ] ta_unit_api_qplc_select_16u_i.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_select_16u_i (0 ms total)

[----------] 1 test from ta_unit_api_qplc_select_32u_i
[ RUN      ] ta_unit_api_qplc_select_32u_i.base
[       OK ] ta_unit_api_qplc_select_32u_i.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_select_32u_i (0 ms total)

[----------] 1 test from ta_unit_api_qplc_unpack_16u
[ RUN      ] ta_unit_api_qplc_unpack_16u.base
[       OK ] ta_unit_api_qplc_unpack_16u.base (1 ms)
[----------] 1 test from ta_unit_api_qplc_unpack_16u (1 ms total)

[----------] 1 test from ta_unit_api_qplc_unpack_32u
[ RUN      ] ta_unit_api_qplc_unpack_32u.base
[       OK ] ta_unit_api_qplc_unpack_32u.base (8 ms)
[----------] 1 test from ta_unit_api_qplc_unpack_32u (8 ms total)

[----------] 1 test from ta_unit_api_qplc_unpack_8u
[ RUN      ] ta_unit_api_qplc_unpack_8u.base
[       OK ] ta_unit_api_qplc_unpack_8u.base (1 ms)
[----------] 1 test from ta_unit_api_qplc_unpack_8u (1 ms total)

[----------] 1 test from ta_unit_api_qplc_unpack_be_16u
[ RUN      ] ta_unit_api_qplc_unpack_be_16u.base
[       OK ] ta_unit_api_qplc_unpack_be_16u.base (1 ms)
[----------] 1 test from ta_unit_api_qplc_unpack_be_16u (1 ms total)

[----------] 1 test from ta_unit_api_qplc_unpack_be_32u
[ RUN      ] ta_unit_api_qplc_unpack_be_32u.base
[       OK ] ta_unit_api_qplc_unpack_be_32u.base (10 ms)
[----------] 1 test from ta_unit_api_qplc_unpack_be_32u (10 ms total)

[----------] 1 test from ta_unit_api_qplc_unpack_be_8u
[ RUN      ] ta_unit_api_qplc_unpack_be_8u.base
[       OK ] ta_unit_api_qplc_unpack_be_8u.base (0 ms)
[----------] 1 test from ta_unit_api_qplc_unpack_be_8u (0 ms total)

[----------] 1 test from ta_unit_api_qplc_unpack_prle_8u
[ RUN      ] ta_unit_api_qplc_unpack_prle_8u.base
[       OK ] ta_unit_api_qplc_unpack_prle_8u.base (2337 ms)
[----------] 1 test from ta_unit_api_qplc_unpack_prle_8u (2337 ms total)

[----------] 1 test from ta_unit_api_qplc_unpack_prle_16u
[ RUN      ] ta_unit_api_qplc_unpack_prle_16u.base
[       OK ] ta_unit_api_qplc_unpack_prle_16u.base (3326 ms)
[----------] 1 test from ta_unit_api_qplc_unpack_prle_16u (3327 ms total)

[----------] 1 test from ta_unit_api_qplc_unpack_prle_32u
[ RUN      ] ta_unit_api_qplc_unpack_prle_32u.base
[       OK ] ta_unit_api_qplc_unpack_prle_32u.base (7888 ms)
[----------] 1 test from ta_unit_api_qplc_unpack_prle_32u (7888 ms total)

[----------] 1 test from ta_unit_api_qpl_zero_8u
[ RUN      ] ta_unit_api_qpl_zero_8u.base
[       OK ] ta_unit_api_qpl_zero_8u.base (0 ms)
[----------] 1 test from ta_unit_api_qpl_zero_8u (0 ms total)

[----------] 5 tests from ta_unit_api_fallback
[ RUN      ] ta_unit_api_fallback.filtering
[       OK ] ta_unit_api_fallback.filtering (0 ms)
[ RUN      ] ta_unit_api_fallback.inflate
[       OK ] ta_unit_api_fallback.inflate (0 ms)
[ RUN      ] ta_unit_api_fallback.deflate
[       OK ] ta_unit_api_fallback.deflate (0 ms)
[ RUN      ] ta_unit_api_fallback.others
[       OK ] ta_unit_api_fallback.others (0 ms)
[ RUN      ] ta_unit_api_fallback.multi_job_support
[       OK ] ta_unit_api_fallback.multi_job_support (0 ms)
[----------] 5 tests from ta_unit_api_fallback (0 ms total)

[----------] Global test environment tear-down
[==========] 47 tests from 42 test suites ran. (15362 ms total)
[  PASSED  ] 47 tests.
Tests seed = 1721404112
```

on-behalf-of: @Permanence-AI-Coder <github-ai@permanence.ai>